### PR TITLE
Fix 404 page not styled properly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+__pycache__/
 site/

--- a/hooks/config.py
+++ b/hooks/config.py
@@ -1,0 +1,10 @@
+import os
+
+url = "https://cordot.readthedocs.io"
+
+def configure(config, **kwargs):
+	if "READTHEDOCS" in os.environ:
+		version = os.environ["READTHEDOCS_VERSION"]
+		language = os.environ["READTHEDOCS_LANGUAGE"]
+		config["site_url"] = f"{url}/{language}/{version}/"
+	return config

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,6 +28,9 @@ markdown_extensions:
 plugins:
     - search
     - awesome-pages
+    - mkdocs-simple-hooks:
+        hooks:
+            on_config: "hooks.config:configure"
 
 nav:
     - 'Class reference':

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 mkdocs==1.3.0
 mkdocs-awesome-pages-plugin==2.7.0
+mkdocs-simple-hooks==0.1.5
 pymdown-extensions==9.5


### PR DESCRIPTION
This change also includes [mkdocs-simple-hooks](https://github.com/aklajnert/mkdocs-simple-hooks) as a dependency now.

The fix was basically setting `site_url` in `mkdocs.yml` to the current built docs URL (`$base/$language/$version` ) if it is built from ReadTheDocs.